### PR TITLE
Handle empty error response

### DIFF
--- a/lib/capsule_crm/errors/response_error.rb
+++ b/lib/capsule_crm/errors/response_error.rb
@@ -8,7 +8,17 @@ module CapsuleCRM
       end
 
       def to_s
-        JSON.parse(response.body)['message']
+        response_message || empty_message
+      end
+
+      private
+
+      def response_message
+        JSON.parse(response.body)['message'] if response
+      end
+
+      def empty_message
+        'capsulecrm.com returned an empty response'
       end
     end
   end

--- a/spec/lib/capsule_crm/errors/response_error_spec.rb
+++ b/spec/lib/capsule_crm/errors/response_error_spec.rb
@@ -1,17 +1,29 @@
 require 'spec_helper'
 
 describe CapsuleCRM::Errors::ResponseError do
+  let(:error) { CapsuleCRM::Errors::ResponseError.new(response) }
+
+  subject { error.to_s }
+
   describe '#to_s' do
-    let(:response) { double('Response', body: response_body.to_json) }
-    let(:response_body) do
-      { message: 'this is an error message from the server' }
+    context 'when the response is not nil' do
+      let(:response) { double('Response', body: response_body.to_json) }
+      let(:response_body) do
+        { message: 'this is an error message from the server' }
+      end
+      let(:error) { CapsuleCRM::Errors::ResponseError.new(response) }
+
+      it 'should include the server error message' do
+        expect(subject).to eql(response_body[:message])
+      end
     end
-    let(:error) { CapsuleCRM::Errors::ResponseError.new(response) }
 
-    subject { error.to_s }
+    context 'when the response is nil' do
+      let(:response) { nil }
 
-    it 'should include the server error message' do
-      expect(subject).to eql(response_body[:message])
+      it 'should return an empty response message' do
+        expect(subject).to eql('capsulecrm.com returned an empty response')
+      end
     end
   end
 end


### PR DESCRIPTION
Gracefully handle situations where capsulecrm returns an error with a blank response. Should resolve #73 
