### PR TITLE
Remove memoization from serializer. Resolves #88

### DIFF
--- a/lib/capsule_crm/serializer.rb
+++ b/lib/capsule_crm/serializer.rb
@@ -8,12 +8,7 @@ module CapsuleCRM
 
     def serialize(object)
       @object = object
-      @serialized ||=
-        if include_root?
-          serialize_with_root
-        else
-          serialize_without_root
-        end
+      include_root? ? serialize_with_root : serialize_without_root
     end
 
     def self.serialize_collection(klass, collection)


### PR DESCRIPTION
Do not memoize the result of CapsuleCRM::Serializer#serialize, otherwise when additional information is added, the serialized version is not updated correctly. This fixes #88 