### PR TITLE
Fix taggable tags

### DIFF
--- a/lib/capsule_crm/taggable.rb
+++ b/lib/capsule_crm/taggable.rb
@@ -3,9 +3,11 @@ module CapsuleCRM
     extend ActiveSupport::Concern
 
     def tags
-      CapsuleCRM::Connection.get(
+      tags = CapsuleCRM::Connection.get(
         "/api/#{api_singular_name}/#{id}/tag"
-      )['tags']['tag'].map { |item| CapsuleCRM::Tag.new(item) }
+      )['tags']['tag']
+      tags = [tags] if tags.is_a? Hash
+      tags.map { |item| CapsuleCRM::Tag.new(item) }
     end
 
     def add_tag(tag_name)

--- a/spec/lib/capsule_crm/taggable_spec.rb
+++ b/spec/lib/capsule_crm/taggable_spec.rb
@@ -34,6 +34,19 @@ describe CapsuleCRM::Taggable do
     it { subject.first.name.should eql('Customer') }
 
     it { subject.last.name.should eql('VIP') }
+
+    context 'when taggable item has one tag' do
+      before do
+        stub_request(:get, /\/api\/taggableitem\/2\/tag$/).
+          to_return(body: File.read('spec/support/one_tag.json'))
+      end
+
+      let(:taggable_item) { TaggableItem.new(id: 2) }
+
+      subject { taggable_item.tags }
+
+      it { should be_a(Array) }
+    end
   end
 
   describe '#add_tag' do

--- a/spec/support/one_tag.json
+++ b/spec/support/one_tag.json
@@ -1,0 +1,7 @@
+{
+  "tags": {
+    "tag": {
+      "name": "Customer"
+    }
+  }
+}


### PR DESCRIPTION
I get the following when I send tags method to an object that has only one tag

NoMethodError: Expected ["id", "1248281"] to respond to #to_hash
from /Users/yvery/.rvm/gems/ruby-2.1.3/gems/virtus-1.0.4/lib/virtus/attribute_set.rb:196:in `coerce'

Capsule's API does not return an Array when there is only one tag. I've use @size param returns by the API to transform the collection tags